### PR TITLE
Refactor authorization_details in sd+jwt-vc format: Move vct and cl…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.4.2]
+
+Refactored: `vct` and `claims` properties of `vc+sd-jwt`, previously nested within `credential_definition`, are now at the top level.
+
 ## [1.4.1]
 
 Changed credential endpoint payload for `jwt_vc_json` to use `credential_definition.type` to support `organisation-wallet` version `0.0.13`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meeco-wallet-cli",
-  "version": "1.3.3",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meeco-wallet-cli",
-      "version": "1.3.3",
+      "version": "1.4.2",
       "dependencies": {
         "@inquirer/prompts": "^3.3.0",
         "@inquirer/select": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "prepare": "npm run build",
     "version": "oclif readme && git add README.md"
   },
-  "version": "1.4.1",
+  "version": "1.4.2",
   "keywords": [
     "oclif",
     "sd-jwt",

--- a/src/types/create-credential-offer.types.ts
+++ b/src/types/create-credential-offer.types.ts
@@ -1,12 +1,12 @@
 export type CredentialMetadata = {
   credential_definition: {
     type?: string[];
-    vct?: string;
   };
   display: Array<{ name: string }>;
   format: string;
   id: string;
   types?: string[];
+  vct?: string;
 };
 
 export type Credential = {

--- a/src/types/openid.types.ts
+++ b/src/types/openid.types.ts
@@ -13,7 +13,6 @@ export enum GRANT_TYPES {
 export type SupportedCredential = {
   credential_definition: {
     type?: string[];
-    vct?: string;
   };
   cryptographic_binding_methods_supported: string[];
   cryptographic_suites_supported: string[];
@@ -24,6 +23,7 @@ export type SupportedCredential = {
   ];
   format: string;
   id: string;
+  vct?: string;
 };
 
 export type SupportedCredentialMap = {

--- a/src/utils/openid/vci.ts
+++ b/src/utils/openid/vci.ts
@@ -41,8 +41,8 @@ class CredentialOfferError extends Error {
 }
 
 function parseSupportedCredential(credentialIdentifier: string, credential: CredentialMetadata): CredentialChoice {
-  const credentialTypes = credential.credential_definition.type ??
-    credential.credential_definition.type ?? [credential.credential_definition.vct as string];
+  const credentialTypes = credential?.credential_definition?.type ??
+    credential?.credential_definition?.type ?? [credential.vct as string];
 
   const vc: Credential = {
     credentialIdentifier,
@@ -170,9 +170,9 @@ async function exchangePreauthCodeWithToken(endpoint: string, code: string, user
 type CredentialOfferMetadata = {
   credential_definition?: {
     type?: string[];
-    vct?: string;
   };
   format: string;
+  vct?: string;
 };
 
 export async function issueVC(issuer: string, endpoint: string, token: TokenSet, metadata: CredentialOfferMetadata) {
@@ -215,10 +215,8 @@ export function getCredentialInfo(
 
   return isVcSdJwt(credentialMetadata)
     ? {
-        credential_definition: {
-          vct: credentialMetadata.credential_definition.vct as string,
-        },
         format: credentialMetadata.format,
+        vct: credentialMetadata.vct,
       }
     : {
         credential_definition: {


### PR DESCRIPTION
Refactored `authorization_details` for `vc+sd-jwt` format: Removed `credential_definition` property. As a result, `vct` and `claims` properties, previously nested within `credential_definition`, are now at the top level.